### PR TITLE
Use config.json theme_version as global assets version (cache-buster)

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "config_version":  "1.2",
+    "theme_version": "2.0.0",
     
     "theme_name" : "_svbk",
     "theme_handle" : "_svbk",

--- a/functions.php
+++ b/functions.php
@@ -440,7 +440,8 @@ function _svbk_scripts() {
 		'_svbk-common',
 		'/dist/css/common.css',
 		[
-			'source' => 'theme'
+			'source' 	=> 'theme',
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);	
 
@@ -453,6 +454,7 @@ function _svbk_scripts() {
 			'source'    => 'theme',
 			'condition' => is_front_page(),
 			'prefetch'  => ! is_front_page(),
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);
 	
@@ -464,6 +466,7 @@ function _svbk_scripts() {
 			'source'    => 'theme',
 			'condition' => is_home() || is_category() || is_tag() || is_post_type_archive( 'post' ),
 			'prefetch'  => ! is_home() && ! is_post_type_archive( 'post' ),
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);
 
@@ -475,6 +478,7 @@ function _svbk_scripts() {
 			'source'    => 'theme',
 			'condition' => is_singular( 'post' ),
 			'prefetch'  => is_home(),
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);
 
@@ -486,6 +490,7 @@ function _svbk_scripts() {
 			'source'    => 'theme',
 			'condition' => is_page() && ! ( is_front_page() || is_home() ),
 			'prefetch'  => is_page(),
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);
 
@@ -497,6 +502,7 @@ function _svbk_scripts() {
 			'source'    => 'theme',
 			'condition' => is_singular( 'testimonial' ),
 			'prefetch'  => is_post_type_archive( 'testimonial' ),
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);	
 	
@@ -507,6 +513,7 @@ function _svbk_scripts() {
 			'deps'      => array( '_svbk-common' ),
 			'source'    => 'theme',
 			'condition' => is_search(),
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);
 
@@ -517,6 +524,7 @@ function _svbk_scripts() {
 			'deps'      => array( '_svbk-common' ),
 			'source'    => 'theme',
 			'condition' => is_404(),
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);
 
@@ -525,8 +533,9 @@ function _svbk_scripts() {
 		'_svbk-ie9',
 		'/dist/css/ie9.css',
 		[
-			'deps'   => array( '_svbk-common' ),
-			'source' => 'theme',
+			'deps'   	=> array( '_svbk-common' ),
+			'source' 	=> 'theme',
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);
 	wp_style_add_data( '_svbk-ie9', 'conditional', 'IE 9' );
@@ -535,8 +544,9 @@ function _svbk_scripts() {
 		'_svbk-ie8',
 		'/dist/css/ie8.css',
 		[
-			'deps'   => array( '_svbk-common' ),
-			'source' => 'theme',
+			'deps'   	=> array( '_svbk-common' ),
+			'source' 	=> 'theme',
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);
 	wp_style_add_data( '_svbk-ie8', 'conditional', 'lt IE 9' );
@@ -546,9 +556,10 @@ function _svbk_scripts() {
 		'_svbk-navigation',
 		'/dist/js/navigation.min.js',
 		[
-			'source' => 'theme',
-			'async'  => true,
-			'defer'  => false,
+			'source' 	=> 'theme',
+			'async'  	=> true,
+			'defer'  	=> false,
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);
 
@@ -556,7 +567,8 @@ function _svbk_scripts() {
 		'jquery-countdown',
 		'dist/jquery.countdown.min.js',
 		[
-			'deps' => array( 'jquery' ),
+			'deps' 		=> array( 'jquery' ),
+			'version' 	=> '2.2.0'
 		]
 	);
 
@@ -565,8 +577,9 @@ function _svbk_scripts() {
 		'_svbk-theme',
 		'/dist/js/theme.min.js',
 		[
-			'deps'   => array( 'jquery', 'jquery-countdown' ),
-			'source' => 'theme',
+			'deps'   	=> array( 'jquery', 'jquery-countdown' ),
+			'source' 	=> 'theme',
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);
 	
@@ -575,8 +588,9 @@ function _svbk_scripts() {
 		'_svbk-theme-fx',
 		'/dist/js/fx.min.js',
 		[
-			'deps'   => array( 'jquery', 'waypoints' ),
-			'source' => 'theme',
+			'deps'   	=> array( 'jquery', 'waypoints' ),
+			'source' 	=> 'theme',
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);	
 
@@ -585,8 +599,9 @@ function _svbk_scripts() {
 		'_svbk-maps',
 		'/dist/js/map-block.min.js',
 		[
-			'deps'   => array( 'jquery' ),
-			'source' => 'theme',
+			'deps'   	=> array( 'jquery' ),
+			'source' 	=> 'theme',
+			'version' 	=> Config::get( 'theme_version', '_svbk' )
 		]
 	);
 
@@ -595,7 +610,7 @@ function _svbk_scripts() {
 		'object-fit-images',
 		'dist/ofi.js',
 		[
-			'version' => '3',
+			'version' => '3.2.4',
 			'defer'   => true,
 		]
 	);
@@ -730,6 +745,7 @@ function _svbk_enqueue_config_fonts( $config_key = 'fonts', $prefix = null, $che
 		'fontfaceobserver.js',
 		[
 			'source' => JsDelivr::class,
+			'version' => Config::get( 'theme_version', '_svbk' ),
 			'defer'  => true,
 		]
 	);
@@ -754,7 +770,14 @@ function _svbk_enqueue_config_fonts( $config_key = 'fonts', $prefix = null, $che
 
 	foreach ( $font_sources as $font_url => $font_handle ) {
 		$is_absolute = preg_match( '|^(https?:)?//|', $font_url );
-		Style::enqueue( $prefix . $font_handle, $font_url, [ 'source' => $is_absolute ? false : 'theme' ] );
+		Style::enqueue( 
+			$prefix . $font_handle, 
+			$font_url, 
+			[ 
+				'source' => $is_absolute ? false : 'theme', 
+				'version' => $is_absolute ? null : Config::get( 'theme_version', '_svbk' ) 
+			] 
+		); 
 	}
 
 	$observerCode = '(function(){ ';

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -9,6 +9,7 @@
 use \Svbk\WP\Helpers\Assets\Style;
 use \Svbk\WP\Helpers\Assets\Script;
 use \Svbk\WP\Integrations;
+use Svbk\WP\Helpers\Config;
 
 /**
  * WooCommerce setup function.
@@ -59,6 +60,7 @@ function _svbk_woocommerce_scripts() {
 			'source'    => 'theme',
 			'condition' => is_product(),
 			'prefetch'  => is_shop() || is_archive( 'product' ),
+			'version' => Config::get( 'theme_version', '_svbk' )
 		]
 	);
 	Style::enqueue(
@@ -68,6 +70,7 @@ function _svbk_woocommerce_scripts() {
 			'source'    => 'theme',
 			'condition' => is_cart(),
 			'prefetch'  => is_product(),
+			'version' => Config::get( 'theme_version', '_svbk' )
 		]
 	);
 	
@@ -78,6 +81,7 @@ function _svbk_woocommerce_scripts() {
 			'source'    => 'theme',
 			'condition' => is_checkout(),
 			'prefetch'  => is_cart(),
+			'version' => Config::get( 'theme_version', '_svbk' )
 		]
 	);
 	
@@ -87,6 +91,7 @@ function _svbk_woocommerce_scripts() {
 		[
 			'source'    => 'theme',
 			'condition' => is_account_page(),
+			'version' => Config::get( 'theme_version', '_svbk' )
 		]
 	);
 	Style::enqueue(
@@ -95,6 +100,7 @@ function _svbk_woocommerce_scripts() {
 		[
 			'source'    => 'theme',
 			'condition' => is_shop() || is_archive( 'product' ),
+			'version' => Config::get( 'theme_version', '_svbk' )
 		]
 	);
 
@@ -109,9 +115,8 @@ function _svbk_woocommerce_scripts() {
 			'source'    => 'theme',
 			'condition' => is_checkout(),
 			'prefetch'  => is_cart(),
-			'deps'      => [
-				'jquery',
-			],
+			'deps'      => [ 'jquery' ],
+			'version' => Config::get( 'theme_version', '_svbk' )
 		]
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Underscores! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Use `theme_version` in  `config.json` as global assets variable. This  allows CSS, JS, etc changes to be deployed with more ease.

```json
{
    "theme_version": "2.0.0",
}
```

Produces
```
dist/css/common.css?ver=2.0.0
dist/css/single-post.css?ver=2.0.0
...
```

Now every time we made a change in assets we must remember to update the _version_ in `config.json` before deployment.

